### PR TITLE
Add Graphviz to make dot available

### DIFF
--- a/edu.stanford.protege.json
+++ b/edu.stanford.protege.json
@@ -5,6 +5,12 @@
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk11"],
     "command": "protege",
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/share/man"
+    ],
     "finish-args": [
         "--env=PATH=/app/bin:/app/jre/bin:/usr/bin",
         "--socket=x11",
@@ -17,6 +23,17 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": ["/usr/lib/sdk/openjdk11/install.sh"]
+        },
+        {
+            "name": "graphviz",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.xz",
+                    "sha256": "85e34b5c982777c30f01dfab9ea7c713b4335a2f584e62c0abb9868413eb915b"
+                }
+            ]
         },
         {
             "name": "protege",


### PR DESCRIPTION
This makes dot available under `/app/bin/dot`. The user has to configure this manually afterward in the user interface.

I think the default lies within the OWLViz JAR, so it might not be easy to edit.

Fix #9 
